### PR TITLE
fix expiry condition

### DIFF
--- a/programs/gpl_session/src/lib.rs
+++ b/programs/gpl_session/src/lib.rs
@@ -456,7 +456,7 @@ impl SessionTokenV2 {
 impl SessionTokenV2 {
     pub fn is_expired(&self) -> Result<bool> {
         let now = Clock::get()?.unix_timestamp;
-        Ok(now < self.valid_until)
+        Ok(now > self.valid_until)
     }
 
     // validate the token


### PR DESCRIPTION
## Problem

The condition to check whether the session is expired was inverted.


## Solution

Correct the condition in `is_expired` method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token expiration validation logic to correctly identify expired sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->