### PR TITLE
fix: support Anchor 0.32+ by defining LAMPORTS_PER_SOL constant

### DIFF
--- a/programs/gpl_session/src/lib.rs
+++ b/programs/gpl_session/src/lib.rs
@@ -1,7 +1,8 @@
-use anchor_lang::{prelude::*, solana_program::native_token::LAMPORTS_PER_SOL, system_program};
+use anchor_lang::{prelude::*, system_program};
 
 #[cfg(feature = "no-entrypoint")]
 pub use session_keys_macros::*;
+const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
 
 declare_id!("KeyspM2ssCJbqUhQ4k7sveSiY4WjnYsrXkC8oDbwde5");
 


### PR DESCRIPTION
## Problem
Compilation fails with Anchor 0.32+ due to the removal of the `native_token` module:
```
error[E0432]: unresolved import `anchor_lang::solana_program::native_token`
 --> programs/gpl_session/src/lib.rs:1:47
  |
1 | use anchor_lang::{prelude::*, solana_program::native_token::LAMPORTS_PER_SOL, system_program};
  |                                               ^^^^^^^^^^^^ could not find `native_token` in `solana_program`
```

This breaks compatibility for all users attempting to build with Anchor 0.32.1 or higher.

## Solution
Removed the import of `LAMPORTS_PER_SOL` from `solana_program::native_token` and defined it as a constant directly in the code:
```rust
const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
```

This approach:
- ✅ Works with all Anchor versions (0.28 - 0.32+)
- ✅ Has no runtime impact (constant is inlined at compile time)
- ✅ Is safe because `LAMPORTS_PER_SOL` is a Solana protocol constant that will never change
- ✅ Maintains backward compatibility

## Before & After Screenshots

**BEFORE**:
```rust
use anchor_lang::{prelude::*, solana_program::native_token::LAMPORTS_PER_SOL, system_program};
```
Result: ❌ Compilation error with Anchor 0.32+

**AFTER**:
```rust
use anchor_lang::{prelude::*, system_program};

const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
```
Result: ✅ Compiles successfully with all Anchor versions

## Other changes (e.g. bug fixes, small refactors)
None - this is a minimal focused fix affecting only the import statement.

## Deploy Notes
No deployment changes required. This is purely a compilation fix with no runtime behavioral changes.

**New scripts**: None

**New dependencies**: None

---

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | No | N/A |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal constant management with no changes to public functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->