### PR TITLE
Add macros for V2

### DIFF
--- a/programs/gpl_session/Cargo.toml
+++ b/programs/gpl_session/Cargo.toml
@@ -20,6 +20,6 @@ default = []
 idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
-anchor-lang = "^0"
+anchor-lang = "0.31.0"
 solana-security-txt = "^1.1.1"
 session-keys-macros = { version = "^0.1.2", path = "macros", optional = true }

--- a/programs/gpl_session/macros/attribute/src/lib.rs
+++ b/programs/gpl_session/macros/attribute/src/lib.rs
@@ -27,47 +27,60 @@ fn is_session(attr: &syn::Attribute) -> bool {
     attr.path.is_ident("session")
 }
 
-fn is_option_account_sessiontoken(ty: &Type) -> bool {
+enum SessionTokenType {
+    V1,
+    V2,
+}
+
+fn get_session_token_type(ty: &Type) -> Option<SessionTokenType> {
     let Type::Path(TypePath { path, .. }) = ty else {
-        return false;
+        return None;
     };
     let Some(seg) = path.segments.first() else {
-        return false;
+        return None;
     };
     if seg.ident != "Option" {
-        return false;
+        return None;
     }
     let PathArguments::AngleBracketed(ref opt_args) = seg.arguments else {
-        return false;
+        return None;
     };
     let Some(GenericArgument::Type(Type::Path(TypePath {
         path: acct_path, ..
     }))) = opt_args.args.first()
     else {
-        return false;
+        return None;
     };
     let Some(acct_seg) = acct_path.segments.first() else {
-        return false;
+        return None;
     };
     if acct_seg.ident != "Account" {
-        return false;
+        return None;
     }
     let PathArguments::AngleBracketed(ref acct_args) = acct_seg.arguments else {
-        return false;
+        return None;
     };
     let mut args = acct_args.args.iter();
     let Some(GenericArgument::Lifetime(_)) = args.next() else {
-        return false;
+        return None;
     };
     let Some(GenericArgument::Type(Type::Path(TypePath { path: st_path, .. }))) = args.next()
     else {
-        return false;
+        return None;
     };
-    st_path.segments.len() == 1 && st_path.segments[0].ident == "SessionToken"
+
+    if st_path.segments.len() == 1 {
+        if st_path.segments[0].ident == "SessionToken" {
+            return Some(SessionTokenType::V1);
+        } else if st_path.segments[0].ident == "SessionTokenV2" {
+            return Some(SessionTokenType::V2);
+        }
+    }
+    None
 }
 
-// Macro to derive Session Trait
-#[proc_macro_derive(Session, attributes(session))]
+// Macro to derive Session Trait (supports both SessionToken and SessionTokenV2)
+#[proc_macro_derive(SessionV2, attributes(session))]
 pub fn derive(input: TokenStream) -> TokenStream {
     let input_parsed = parse_macro_input!(input as DeriveInput);
 
@@ -85,10 +98,10 @@ pub fn derive(input: TokenStream) -> TokenStream {
         .iter()
         .find(|field| field.ident.as_ref().unwrap().to_string() == "session_token")
         .expect("Session trait can only be derived for structs with a session_token field");
-    {
-        let session_token_type = &session_token_field.ty;
-        assert!(is_option_account_sessiontoken(session_token_type), "Session trait can only be derived for structs with a session_token field of type Option<Account<'info, SessionToken>>");
-    }
+
+    let session_token_type = &session_token_field.ty;
+    let token_type = get_session_token_type(session_token_type)
+        .expect("Session trait can only be derived for structs with a session_token field of type Option<Account<'info, SessionToken>> or Option<Account<'info, SessionTokenV2>>");
 
     // Session Token field must have the #[session] attribute
     let session_attr = session_token_field
@@ -107,35 +120,68 @@ pub fn derive(input: TokenStream) -> TokenStream {
     let struct_name = &input_parsed.ident;
     let (impl_generics, ty_generics, where_clause) = input_parsed.generics.split_for_impl();
 
-    let output = quote! {
+    let output = match token_type {
+        SessionTokenType::V1 => quote! {
+            #[automatically_derived]
+            impl #impl_generics Session #ty_generics for #struct_name #ty_generics #where_clause {
 
-        #[automatically_derived]
-        impl #impl_generics Session #ty_generics for #struct_name #ty_generics #where_clause {
+                // Target Program
+                fn target_program(&self) -> Pubkey {
+                    crate::id()
+                }
 
-            // Target Program
-            fn target_program(&self) -> Pubkey {
-                crate::id()
+                // Session Token
+                fn session_token(&self) -> Option<Account<'info, SessionToken>> {
+                    self.session_token.clone()
+                }
+
+                // Session Authority
+                fn session_authority(&self) -> Pubkey {
+                    self.#session_authority
+                }
+
+                // Session Signer
+                fn session_signer(&self) -> Signer<'info> {
+                    self.#session_signer.clone()
+                }
+
             }
+        },
+        SessionTokenType::V2 => quote! {
+            #[automatically_derived]
+            impl #impl_generics SessionV2 #ty_generics for #struct_name #ty_generics #where_clause {
 
-            // Session Token
-            fn session_token(&self) -> Option<Account<'info, SessionToken>> {
-                self.session_token.clone()
+                // Target Program
+                fn target_program(&self) -> Pubkey {
+                    crate::id()
+                }
+
+                // Session Token
+                fn session_token(&self) -> Option<Account<'info, SessionTokenV2>> {
+                    self.session_token.clone()
+                }
+
+                // Session Authority
+                fn session_authority(&self) -> Pubkey {
+                    self.#session_authority
+                }
+
+                // Session Signer
+                fn session_signer(&self) -> Signer<'info> {
+                    self.#session_signer.clone()
+                }
+
             }
-
-            // Session Authority
-            fn session_authority(&self) -> Pubkey {
-                self.#session_authority
-            }
-
-            // Session Signer
-            fn session_signer(&self) -> Signer<'info> {
-                self.#session_signer.clone()
-            }
-
-        }
+        },
     };
 
     output.into()
+}
+
+// Macro to derive SessionV2 Trait (alias for Session macro for backwards compatibility)
+#[proc_macro_derive(Session, attributes(session))]
+pub fn derive_v2(input: TokenStream) -> TokenStream {
+    derive(input)
 }
 
 struct SessionAuthArgs(syn::Expr, syn::Expr);
@@ -150,7 +196,8 @@ impl Parse for SessionAuthArgs {
 }
 
 #[proc_macro_attribute]
-/// Macro to check if the session or the original authority is the signer
+/// Macro to check if the session (V1 or V2) or the original authority is the signer
+/// This macro works with both Session and SessionV2 traits
 pub fn session_auth_or(attr: TokenStream, item: TokenStream) -> TokenStream {
     let SessionAuthArgs(auth_expr, error_ty) = parse_macro_input!(attr);
 

--- a/programs/gpl_session/src/lib.rs
+++ b/programs/gpl_session/src/lib.rs
@@ -456,7 +456,7 @@ impl SessionTokenV2 {
 impl SessionTokenV2 {
     pub fn is_expired(&self) -> Result<bool> {
         let now = Clock::get()?.unix_timestamp;
-        Ok(now < self.valid_until)
+        Ok(now > self.valid_until)
     }
 
     // validate the token


### PR DESCRIPTION
## Problem

https://github.com/magicblock-labs/session-keys/pull/9 introduced V2 instructions but didnt have macros that could be used in the contract.


## Solution

Add macros to support V2 instructions similar to V1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for V2 session tokens, enabling dual-variant session token handling alongside existing V1 tokens.

* **Bug Fixes**
  * Corrected session token expiration logic to properly detect expired tokens.

* **Chores**
  * Updated anchor-lang dependency to version 0.31.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->